### PR TITLE
Avoid primary key collisions

### DIFF
--- a/migrations/2022-10-27-082801_mb-earnings-tracking/up.sql
+++ b/migrations/2022-10-27-082801_mb-earnings-tracking/up.sql
@@ -59,6 +59,20 @@ from nft_listings l
 where l.kind = 'auction'
 order by nft_contract_id, token_id, market_id, approval_id, o.offered_at desc;
 
+-- change nft-earnings-pkey
+alter table nft_earnings drop constraint nft_earnings_pkey;
+alter table nft_earnings alter is_referral set not null;
+alter table nft_earnings alter is_mintbase_cut set not null;
+alter table nft_earnings add primary key (
+  nft_contract_id,
+  token_id,
+  market_id,
+  approval_id,
+  receiver_id,
+  is_referral,
+  is_mintbase_cut
+);
+
 insert into nft_earnings (
   nft_contract_id,
   token_id,

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -59,7 +59,7 @@ table! {
 }
 
 table! {
-    nft_earnings (nft_contract_id, token_id, market_id, approval_id, receiver_id) {
+    nft_earnings (nft_contract_id, token_id, market_id, approval_id, receiver_id, is_referral, is_mintbase_cut) {
         nft_contract_id -> Text,
         token_id -> Text,
         market_id -> Text,


### PR DESCRIPTION
This PR

- [ ] does a DB schema change
  - [ ] hasura permissions are updated
  - [ ] the indexer is halted
  - [ ] the corresponding minterop-producer PR is ready
  - [ ] the corresponding minterop-consumer PR is ready
- [ ] changes pubsub payloads
  - [ ] the indexer is halted
  - [ ] the corresponding minterop-producer PR is ready
  - [ ] the corresponding minterop-consumer PR is ready
- [ ] deprecates hasura permissions
  - [ ] frontend won't break
- [ ] creates hasura triggers/actions/events etc.
  - [ ] postgres DB user has been granted appropriate permissions
