### PR TITLE
Ignoring conflicts for MB cut tracking

### DIFF
--- a/migrations/2022-10-27-082801_mb-earnings-tracking/down.sql
+++ b/migrations/2022-10-27-082801_mb-earnings-tracking/down.sql
@@ -1,3 +1,14 @@
+delete from nft_earnings where is_mintbase_cut is TRUE;
+alter table nft_earnings drop constraint nft_earnings_pkey;
+alter table nft_earnings alter is_referral set not null;
+alter table nft_earnings alter is_mintbase_cut set not null;
+alter table nft_earnings add primary key (
+  nft_contract_id,
+  token_id,
+  market_id,
+  approval_id,
+  receiver_id
+);
 alter table nft_earnings drop column is_mintbase_cut;
 
 drop view mb_views.auctions_with_offer;
@@ -54,7 +65,6 @@ from nft_listings l
     and l.approval_id = o.approval_id
 where l.kind = 'auction'
 order by nft_contract_id, token_id, market_id, approval_id, o.offered_at desc;
-
 
 drop view mb_views.nft_tokens_with_listing;
 create view mb_views.nft_tokens_with_listing

--- a/migrations/2022-10-27-082801_mb-earnings-tracking/up.sql
+++ b/migrations/2022-10-27-082801_mb-earnings-tracking/up.sql
@@ -100,7 +100,8 @@ insert into nft_earnings (
     'f', -- is_referral
     't' -- is_mintbase_cut
 from nft_offers
-where accepted_at is not null;
+where accepted_at is not null
+on conflict do nothing;
 
 -- fix mb_views.tokens_with_listing.reference_blob
 drop view mb_views.nft_tokens_with_listing;

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -91,6 +91,7 @@ table! {
         accepted_at -> Nullable<Timestamp>,
         accepted_offer_id -> Nullable<Int8>,
         metadata_id -> Nullable<Text>,
+        new_metadata_id -> Nullable<Text>,
         invalidated_at -> Nullable<Timestamp>,
     }
 }
@@ -109,6 +110,10 @@ table! {
         extra -> Nullable<Text>,
         minter -> Nullable<Text>,
         base_uri -> Nullable<Text>,
+        old_id -> Nullable<Text>,
+        old_reference -> Nullable<Text>,
+        old_media -> Nullable<Text>,
+        new_media -> Nullable<Text>,
     }
 }
 
@@ -158,6 +163,8 @@ table! {
         royalties_percent -> Nullable<Int4>,
         royalties -> Nullable<Jsonb>,
         splits -> Nullable<Jsonb>,
+        old_metadata_id -> Nullable<Text>,
+        old_reference -> Nullable<Text>,
     }
 }
 


### PR DESCRIPTION
This needs to be done as some listings seem to have multiple accepted offers.

This PR

- [ ] does a DB schema change
  - [ ] hasura permissions are updated
  - [ ] the indexer is halted
  - [ ] the corresponding minterop-producer PR is ready
  - [ ] the corresponding minterop-consumer PR is ready
- [ ] changes pubsub payloads
  - [ ] the indexer is halted
  - [ ] the corresponding minterop-producer PR is ready
  - [ ] the corresponding minterop-consumer PR is ready
- [ ] deprecates hasura permissions
  - [ ] frontend won't break
- [ ] creates hasura triggers/actions/events etc.
  - [ ] postgres DB user has been granted appropriate permissions
