### PR TITLE
Fixing hasura metadata for activities rollup

### DIFF
--- a/hasura/metadata/databases/minterop/tables/mb_views_nft_activities_rollup.yaml
+++ b/hasura/metadata/databases/minterop/tables/mb_views_nft_activities_rollup.yaml
@@ -24,7 +24,7 @@ select_permissions:
         - price
         - reference
         - reference_blob
-        - id as metadata_id
+        - metadata_id
         - title
         - description
         - media

--- a/hasura/metadata/databases/minterop/tables/tables.yaml
+++ b/hasura/metadata/databases/minterop/tables/tables.yaml
@@ -2,6 +2,7 @@
 - "!include mb_views_active_listings.yaml"
 - "!include mb_views_auctions_with_offer.yaml"
 - "!include mb_views_nft_activities.yaml"
+- "!include mb_views_nft_activities_rollup.yaml"
 - "!include mb_views_nft_metadata_unburned.yaml"
 - "!include mb_views_nft_metadata.yaml"
 - "!include mb_views_nft_tokens_with_listing.yaml"


### PR DESCRIPTION
This PR

- [ ] does a DB schema change
  - [ ] hasura permissions are updated
  - [ ] the indexer is halted
  - [ ] the corresponding minterop-producer PR is ready
  - [ ] the corresponding minterop-consumer PR is ready
- [ ] changes pubsub payloads
  - [ ] the indexer is halted
  - [ ] the corresponding minterop-producer PR is ready
  - [ ] the corresponding minterop-consumer PR is ready
- [ ] deprecates hasura permissions
  - [ ] frontend won't break
- [ ] creates hasura triggers/actions/events etc.
  - [ ] postgres DB user has been granted appropriate permissions
