### PR TITLE
Enabling action_sender/receiver for all activities

### DIFF
--- a/src/db_rows.rs
+++ b/src/db_rows.rs
@@ -200,7 +200,7 @@ pub struct NftActivity {
     pub token_id: String,
     pub kind: String,
     /// transfers, approvals, revokes
-    pub action_sender: Option<String>,
+    pub action_sender: String,
     pub action_receiver: Option<String>,
     pub memo: Option<String>,
     /// only on listing events

--- a/src/db_rows.rs
+++ b/src/db_rows.rs
@@ -236,8 +236,8 @@ pub struct NftListing {
     pub unlisted_at: Option<NaiveDateTime>,
     pub accepted_at: Option<NaiveDateTime>,
     pub accepted_offer_id: Option<i64>,
-    pub invalidated_at: Option<NaiveDateTime>,
     pub metadata_id: Option<String>,
+    pub invalidated_at: Option<NaiveDateTime>,
 }
 
 pub const NFT_LISTING_KIND_SIMPLE: &str = "simple";


### PR DESCRIPTION
# Do not merge until downstream PR ready

This PR

- [ ] does a DB schema change
  - [ ] hasura permissions are updated
  - [ ] the indexer is halted
  - [ ] the corresponding minterop-producer PR is ready
  - [ ] the corresponding minterop-consumer PR is ready
- [ ] changes pubsub payloads
  - [ ] the indexer is halted
  - [ ] the corresponding minterop-producer PR is ready
  - [ ] the corresponding minterop-consumer PR is ready
- [ ] deprecates hasura permissions
  - [ ] frontend won't break
- [ ] creates hasura triggers/actions/events etc.
  - [ ] postgres DB user has been granted appropriate permissions
