### PR TITLE
fix: :card_file_box: Use one of two timestamps in token join

### DIFF
--- a/migrations/2023-01-11-122654_use-last-transfer-in-meta/down.sql
+++ b/migrations/2023-01-11-122654_use-last-transfer-in-meta/down.sql
@@ -1,0 +1,37 @@
+rop view mb_views.nft_metadata_unburned;
+
+create view mb_views.nft_metadata_unburned as
+select md.id as metadata_id,
+  md.title,
+  md.description,
+  md.media,
+  md.nft_contract_id,
+  md.base_uri,
+  md.reference_blob,
+  md.content_flag,
+  t.minted_timestamp,
+  t.minter,
+  l.price
+from nft_metadata md
+left join lateral (
+  select
+    t.minted_timestamp,
+    t.minter
+  from nft_tokens t
+  where
+    t.burned_timestamp is null and t.metadata_id = md.id
+  order by t.minted_timestamp desc
+  limit 1
+) t on true
+left join lateral (
+  select p.price
+  from nft_listings p
+  where
+    p.unlisted_at is null and
+    p.accepted_at is null and
+    p.invalidated_at is null and
+    p.metadata_id = md.id
+  order by p.price asc
+  limit 1
+) l on true
+where t.minted_timestamp is not null;

--- a/migrations/2023-01-11-122654_use-last-transfer-in-meta/up.sql
+++ b/migrations/2023-01-11-122654_use-last-transfer-in-meta/up.sql
@@ -1,0 +1,39 @@
+rop view mb_views.nft_metadata_unburned;
+
+create view mb_views.nft_metadata_unburned as
+select md.id as metadata_id,
+  md.title,
+  md.description,
+  md.media,
+  md.nft_contract_id,
+  md.base_uri,
+  md.reference_blob,
+  md.content_flag,
+  t.minted_timestamp,
+  t.last_transfer_timestamp,
+  t.minter,
+  l.price
+from nft_metadata md
+left join lateral (
+  select
+    t.minted_timestamp,
+    t.last_transfer_timestamp,
+    t.minter
+  from nft_tokens t
+  where
+    t.burned_timestamp is null and t.metadata_id = md.id
+  order by greatest(t.minted_timestamp, t.last_transfer_timestamp) desc
+  limit 1
+) t on true
+left join lateral (
+  select p.price
+  from nft_listings p
+  where
+    p.unlisted_at is null and
+    p.accepted_at is null and
+    p.invalidated_at is null and
+    p.metadata_id = md.id
+  order by p.price asc
+  limit 1
+) l on true
+where coalesce(t.last_transfer_timestamp, t.minted_timestamp) is not null;


### PR DESCRIPTION
This PR

- [ ] does a DB schema change
  - [ ] hasura permissions are updated
  - [ ] the indexer is halted
  - [ ] the corresponding minterop-producer PR is ready
  - [ ] the corresponding minterop-consumer PR is ready
- [ ] changes pubsub payloads
  - [ ] the indexer is halted
  - [ ] the corresponding minterop-producer PR is ready
  - [ ] the corresponding minterop-consumer PR is ready
- [ ] deprecates hasura permissions
  - [ ] frontend won't break
- [ ] creates hasura triggers/actions/events etc.
  - [ ] postgres DB user has been granted appropriate permissions
