### PR TITLE
Fix gin index by using trigram ops

### DIFF
--- a/migrations/2023-03-20-103818_fix-gin-index/down.sql
+++ b/migrations/2023-03-20-103818_fix-gin-index/down.sql
@@ -1,0 +1,9 @@
+drop index nft_attributes_search_index;
+create index nft_attributes_search_index
+on public.nft_attributes
+using gin(
+  nft_contract_id,
+  attribute_type,
+  attribute_value
+);
+drop extension pg_trgm;

--- a/migrations/2023-03-20-103818_fix-gin-index/up.sql
+++ b/migrations/2023-03-20-103818_fix-gin-index/up.sql
@@ -1,0 +1,9 @@
+create extension if not exists pg_trgm;
+drop index nft_attributes_search_index;
+create index nft_attributes_search_index
+on public.nft_attributes
+using gin(
+  nft_contract_id gin_trgm_ops,
+  attribute_type gin_trgm_ops,
+  attribute_value gin_trgm_ops
+);


### PR DESCRIPTION
This PR

- [ ] does a DB schema change
  - [ ] hasura permissions are updated
  - [ ] the indexer is halted
  - [ ] the corresponding minterop-producer PR is ready
  - [ ] the corresponding minterop-consumer PR is ready
- [ ] changes pubsub payloads
  - [ ] the indexer is halted
  - [ ] the corresponding minterop-producer PR is ready
  - [ ] the corresponding minterop-consumer PR is ready
- [ ] deprecates hasura permissions
  - [ ] frontend won't break
- [ ] creates hasura triggers/actions/events etc.
  - [ ] postgres DB user has been granted appropriate permissions
