### PR TITLE
Adding blockheight to activities table

### DIFF
--- a/hasura/metadata/databases/minterop/tables/mb_views_nft_activities.yaml
+++ b/hasura/metadata/databases/minterop/tables/mb_views_nft_activities.yaml
@@ -24,6 +24,7 @@ select_permissions:
         - media_hash
         - nft_contract_id
         - price
+        - blockheight
         - receipt_id
         - reference
         - reference_hash

--- a/hasura/metadata/databases/minterop/tables/public_nft_activities.yaml
+++ b/hasura/metadata/databases/minterop/tables/public_nft_activities.yaml
@@ -34,5 +34,6 @@ select_permissions:
         - token_id
         - tx_sender
         - timestamp
+        - blockheight
       filter: {}
       allow_aggregations: true

--- a/migrations/2023-03-30-135947_add-blockheight-to-activities/down.sql
+++ b/migrations/2023-03-30-135947_add-blockheight-to-activities/down.sql
@@ -1,0 +1,30 @@
+alter table nft_activities drop column blockheight;
+
+drop view mb_views.nft_activities;
+create view mb_views.nft_activities as
+  select
+    a.receipt_id,
+    a.tx_sender,
+    a.timestamp,
+    a.nft_contract_id,
+    a.token_id,
+    a.kind,
+    a.action_sender,
+    a.action_receiver,
+    a.price,
+    t.reference,
+    t.reference_hash,
+    t.copies,
+    m.title,
+    m.description,
+    m.media,
+    m.media_hash,
+    m.extra,
+    m.reference_blob,
+    m.content_flag
+  from nft_activities a
+    left join nft_tokens t
+      on a.nft_contract_id = t.nft_contract_id
+      and a.token_id = t.token_id
+    left join nft_metadata m
+      on t.metadata_id = m.id;

--- a/migrations/2023-03-30-135947_add-blockheight-to-activities/up.sql
+++ b/migrations/2023-03-30-135947_add-blockheight-to-activities/up.sql
@@ -1,0 +1,31 @@
+alter table nft_activities add column blockheight numeric;
+
+drop view mb_views.nft_activities;
+create view mb_views.nft_activities as
+  select
+    a.receipt_id,
+    a.tx_sender,
+    a.timestamp,
+    a.nft_contract_id,
+    a.token_id,
+    a.kind,
+    a.action_sender,
+    a.action_receiver,
+    a.price,
+    a.blockheight,
+    t.reference,
+    t.reference_hash,
+    t.copies,
+    m.title,
+    m.description,
+    m.media,
+    m.media_hash,
+    m.extra,
+    m.reference_blob,
+    m.content_flag
+  from nft_activities a
+    left join nft_tokens t
+      on a.nft_contract_id = t.nft_contract_id
+      and a.token_id = t.token_id
+    left join nft_metadata m
+      on t.metadata_id = m.id;

--- a/src/db_rows.rs
+++ b/src/db_rows.rs
@@ -198,6 +198,7 @@ pub struct NftActivity {
     pub tx_sender: String,
     pub sender_pk: Option<String>,
     pub timestamp: NaiveDateTime,
+    pub blockheight: u64,
     pub nft_contract_id: String,
     pub token_id: String,
     pub kind: String,

--- a/src/db_rows.rs
+++ b/src/db_rows.rs
@@ -198,7 +198,7 @@ pub struct NftActivity {
     pub tx_sender: String,
     pub sender_pk: Option<String>,
     pub timestamp: NaiveDateTime,
-    pub blockheight: u64,
+    pub blockheight: BigDecimal,
     pub nft_contract_id: String,
     pub token_id: String,
     pub kind: String,

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -26,6 +26,7 @@ table! {
         action_receiver -> Nullable<Text>,
         memo -> Nullable<Text>,
         price -> Nullable<Numeric>,
+        blockheight -> Nullable<Numeric>,
     }
 }
 


### PR DESCRIPTION
# DO NOT MERGE

We should make sure that timestamp is not more appropriate for the use case either way

This PR

- [x] does a DB schema change
  - [x] hasura permissions are updated
  - [ ] the indexer is halted
  - [ ] the corresponding minterop-producer PR is ready
  - [ ] the corresponding minterop-consumer PR is ready
- [ ] changes pubsub payloads
  - [ ] the indexer is halted
  - [ ] the corresponding minterop-producer PR is ready
  - [ ] the corresponding minterop-consumer PR is ready
- [ ] deprecates hasura permissions
  - [ ] frontend won't break
- [ ] creates hasura triggers/actions/events etc.
  - [ ] postgres DB user has been granted appropriate permissions
