### PR TITLE
Incorporate `created_at` into ordering

### DIFF
--- a/hasura/metadata/databases/databases.yaml
+++ b/hasura/metadata/databases/databases.yaml
@@ -41,8 +41,8 @@
           ) _t
         ) t
         ON t.minter = m.minter_id AND t.nft_contract_id = m.nft_contract_id
-        LEFT JOIN (SELECT id, owner_id FROM nft_contracts) c
+        LEFT JOIN (SELECT id, owner_id, created_at FROM nft_contracts) c
         ON c.id = m.nft_contract_id
-        ORDER BY minted_timestamp DESC NULLS LAST
+        ORDER BY GREATEST(minted_timestamp, created_at) DESC NULLS LAST
       returns: launchpad_contracts_model
   tables: "!include minterop/tables/tables.yaml"


### PR DESCRIPTION
This PR

- [ ] does a DB schema change
  - [ ] hasura permissions are updated
  - [ ] the indexer is halted
  - [ ] the corresponding minterop-producer PR is ready
  - [ ] the corresponding minterop-consumer PR is ready
- [ ] changes pubsub payloads
  - [ ] the indexer is halted
  - [ ] the corresponding minterop-producer PR is ready
  - [ ] the corresponding minterop-consumer PR is ready
- [ ] deprecates hasura permissions
  - [ ] frontend won't break
- [ ] creates hasura triggers/actions/events etc.
  - [ ] postgres DB user has been granted appropriate permissions
