### PR TITLE
Optimize `mb_views.active_listings_rollup`

### DIFF
--- a/migrations/2023-10-26-151722_optimize-active-listings-rollup/down.sql
+++ b/migrations/2023-10-26-151722_optimize-active-listings-rollup/down.sql
@@ -1,0 +1,29 @@
+drop view mb_views.active_listings_rollup;
+create view mb_views.active_listings_rollup as
+  select distinct on (metadata_id)
+    l.nft_contract_id,
+    l.token_id,
+    l.market_id,
+    l.approval_id,
+    l.created_at,
+    l.receipt_id,
+    l.kind,
+    l.price,
+    l.currency,
+    l.listed_by,
+    l.metadata_id,
+    m.reference,
+    m.minter,
+    m.title,
+    m.description,
+    m.reference_blob,
+    m.media,
+    m.extra,
+    m.base_uri,
+    m.content_flag
+  from (select * from nft_listings order by created_at desc nulls last) l
+    left join nft_metadata m
+    on l.metadata_id = m.id
+  where l.unlisted_at is null
+    and l.accepted_at is null
+    and l.invalidated_at is null;

--- a/migrations/2023-10-26-151722_optimize-active-listings-rollup/up.sql
+++ b/migrations/2023-10-26-151722_optimize-active-listings-rollup/up.sql
@@ -1,0 +1,36 @@
+drop view mb_views.active_listings_rollup;
+create view mb_views.active_listings_rollup as
+   select
+     l.nft_contract_id,
+     l.token_id,
+     l.market_id,
+     l.approval_id,
+     l.created_at,
+     l.receipt_id,
+     l.kind,
+     l.price,
+     l.currency,
+     l.listed_by,
+     l.metadata_id,
+     m.reference,
+     m.minter,
+     m.title,
+     m.description,
+     m.reference_blob,
+     m.media,
+     m.extra,
+     m.base_uri,
+     m.content_flag
+   from (
+     select *
+     from nft_listings
+     where unlisted_at is null
+       and accepted_at is null
+       and invalidated_at is null
+   ) l
+   left join lateral (
+     select *
+     from nft_metadata m0
+     where m0.id = l.metadata_id
+     order by created_at desc nulls last
+   ) m on true;

--- a/migrations/2023-10-26-151722_optimize-active-listings-rollup/up.sql
+++ b/migrations/2023-10-26-151722_optimize-active-listings-rollup/up.sql
@@ -32,5 +32,4 @@ create view mb_views.active_listings_rollup as
      select *
      from nft_metadata m0
      where m0.id = l.metadata_id
-     order by created_at desc nulls last
    ) m on true;


### PR DESCRIPTION
Recreating the view for a ~10x speed improvement

This PR

- [ ] does a DB schema change
  - [ ] hasura permissions are updated
  - [ ] the indexer is halted
  - [ ] the corresponding minterop-producer PR is ready
  - [ ] the corresponding minterop-consumer PR is ready
- [ ] changes pubsub payloads
  - [ ] the indexer is halted
  - [ ] the corresponding minterop-producer PR is ready
  - [ ] the corresponding minterop-consumer PR is ready
- [ ] deprecates hasura permissions
  - [ ] frontend won't break
- [ ] creates hasura triggers/actions/events etc.
  - [ ] postgres DB user has been granted appropriate permissions
