### PR TITLE
Add `is_active` column to `nft_metadata` table

### DIFF
--- a/hasura/metadata/databases/minterop/tables/public_nft_metadata.yaml
+++ b/hasura/metadata/databases/minterop/tables/public_nft_metadata.yaml
@@ -43,5 +43,6 @@ select_permissions:
         - max_supply
         - last_possible_mint
         - is_locked
+        - is_active
       filter: {}
       allow_aggregations: true

--- a/migrations/2024-03-04-154538_metadata-add-is-active-column/down.sql
+++ b/migrations/2024-03-04-154538_metadata-add-is-active-column/down.sql
@@ -1,0 +1,2 @@
+alter table nft_metadata
+  drop is_active;

--- a/migrations/2024-03-04-154538_metadata-add-is-active-column/up.sql
+++ b/migrations/2024-03-04-154538_metadata-add-is-active-column/up.sql
@@ -1,0 +1,2 @@
+alter table nft_metadata
+  add is_active boolean not null default true;

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -178,6 +178,7 @@ diesel::table! {
         max_supply -> Nullable<Numeric>,
         last_possible_mint -> Nullable<Timestamp>,
         is_locked -> Nullable<Bool>,
+        is_active -> Bool,
     }
 }
 


### PR DESCRIPTION
This PR

- Adds a `is_active` column to `nft_metadata`

Checklist:

- [ ] does a DB schema change
  - [ ] hasura permissions are updated
  - [ ] the indexer is halted
  - [ ] the corresponding minterop-producer PR is ready
  - [ ] the corresponding minterop-consumer PR is ready
- [ ] changes pubsub payloads
  - [ ] the indexer is halted
  - [ ] the corresponding minterop-producer PR is ready
  - [ ] the corresponding minterop-consumer PR is ready
- [ ] deprecates hasura permissions
  - [ ] frontend won't break
- [ ] creates hasura triggers/actions/events etc.
  - [ ] postgres DB user has been granted appropriate permissions
